### PR TITLE
Makes name argument for 'toId' optional

### DIFF
--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -36,8 +36,8 @@ describe('toId', () => {
     );
   });
 
-  it('does not allow empty story', () => {
-    expect(() => toId('kind', '')).toThrow(`Invalid name '', must include alphanumeric characters`);
+  it('allows empty story', () => {
+    expect(() => toId('kind', '')).not.toThrow();
   });
 });
 

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -1,9 +1,10 @@
 import { toId, storyNameFromExport, isExportStory } from '.';
 
 describe('toId', () => {
-  [
+  const testCases: [string, string, string | undefined, string][] = [
     // name, kind, story, output
     ['handles simple cases', 'kind', 'story', 'kind--story'],
+    ['handles kind without story', 'kind', undefined, 'kind'],
     ['handles basic substitution', 'a b$c?d😀e', '1-2:3', 'a-b-c-d😀e--1-2-3'],
     ['handles runs of non-url chars', 'a?&*b', 'story', 'a-b--story'],
     ['removes non-url chars from start and end', '?ab-', 'story', 'ab--story'],
@@ -11,7 +12,9 @@ describe('toId', () => {
     ['non-latin', 'Кнопки', 'нормальный', 'кнопки--нормальный'],
     ['korean', 'kind', '바보 (babo)', 'kind--바보-babo'],
     ['all punctuation', 'kind', 'unicorns,’–—―′¿`"<>()!.!!!{}[]%^&$*#&', 'kind--unicorns'],
-  ].forEach(([name, kind, story, output]) => {
+  ];
+
+  testCases.forEach(([name, kind, story, output]) => {
     it(name, () => {
       expect(toId(kind, story)).toBe(output);
     });

--- a/src/index.ts
+++ b/src/index.ts
@@ -29,9 +29,7 @@ const sanitizeSafe = (string: string, part: string) => {
  * Generate a storybook ID from a component/kind and story name.
  */
 export const toId = (kind: string, name?: string) =>
-  `${sanitizeSafe(kind, 'kind')}${
-    typeof name === 'string' ? `--${sanitizeSafe(name, 'name')}` : ''
-  }`;
+  `${sanitizeSafe(kind, 'kind')}${name ? `--${sanitizeSafe(name, 'name')}` : ''}`;
 
 /**
  * Transform a CSF named export into a readable story name

--- a/src/index.ts
+++ b/src/index.ts
@@ -28,8 +28,10 @@ const sanitizeSafe = (string: string, part: string) => {
 /**
  * Generate a storybook ID from a component/kind and story name.
  */
-export const toId = (kind: string, name: string) =>
-  `${sanitizeSafe(kind, 'kind')}--${sanitizeSafe(name, 'name')}`;
+export const toId = (kind: string, name?: string) =>
+  `${sanitizeSafe(kind, 'kind')}${
+    typeof name === 'string' ? `--${sanitizeSafe(name, 'name')}` : ''
+  }`;
 
 /**
  * Transform a CSF named export into a readable story name


### PR DESCRIPTION
This PR allows generating storybook ID only from a component/kind and would help getting [this](https://github.com/storybookjs/storybook/issues/10846) fixed.