### PR TITLE
Only make `TArgs` parameterize `args` and `argTypes` in our default annotations

### DIFF
--- a/src/story.ts
+++ b/src/story.ts
@@ -261,13 +261,6 @@ export type ComponentAnnotations<
    * By defining them each component will have its tab in the args table.
    */
     subcomponents?: Record<string, TFramework['component']>;
-  
-
-
-  /**
-   * Function that is executed after the story is rendered.
-   */
-  play?: PlayFunction<TFramework, TArgs>;
 };
 
 export type StoryAnnotations<

--- a/src/story.ts
+++ b/src/story.ts
@@ -144,7 +144,7 @@ export type BaseAnnotations<TFramework extends AnyFramework = AnyFramework, TArg
    * Decorators defined in Meta will be applied to every story variation.
    * @see [Decorators](https://storybook.js.org/docs/addons/introduction/#1-decorators)
    */
-  decorators?: DecoratorFunction<TFramework, TArgs>[];
+  decorators?: DecoratorFunction<TFramework, Args>[];
 
   /**
    * Custom metadata for a story.
@@ -168,28 +168,28 @@ export type BaseAnnotations<TFramework extends AnyFramework = AnyFramework, TArg
    * Asynchronous functions which provide data for a story.
    * @see [Loaders](https://storybook.js.org/docs/react/writing-stories/loaders)
    */
-  loaders?: LoaderFunction<TFramework, TArgs>[];
+  loaders?: LoaderFunction<TFramework, Args>[];
 
   /**
    * Define a custom render function for the story(ies). If not passed, a default render function by the framework will be used.
    */
-  render?: ArgsStoryFn<TFramework, TArgs>;
+  render?: ArgsStoryFn<TFramework, Args>;
 
   /**
    * Function that is executed after the story is rendered.
    */
-  play?: PlayFunction<TFramework, TArgs>;
+  play?: PlayFunction<TFramework, Args>;
 };
 
 export type ProjectAnnotations<
   TFramework extends AnyFramework = AnyFramework,
   TArgs = Args
 > = BaseAnnotations<TFramework, TArgs> & {
-  argsEnhancers?: ArgsEnhancer<TFramework, TArgs>[];
-  argTypesEnhancers?: ArgTypesEnhancer<TFramework, TArgs>[];
+  argsEnhancers?: ArgsEnhancer<TFramework, Args>[];
+  argTypesEnhancers?: ArgTypesEnhancer<TFramework, Args>[];
   globals?: Globals;
   globalTypes?: GlobalTypes;
-  applyDecorators?: DecoratorApplicator<TFramework, TArgs>;
+  applyDecorators?: DecoratorApplicator<TFramework, Args>;
 };
 
 type StoryDescriptor = string[] | RegExp;
@@ -289,7 +289,7 @@ export type StoryAnnotations<
 export type LegacyAnnotatedStoryFn<
   TFramework extends AnyFramework = AnyFramework,
   TArgs = Args
-> = StoryFn<TFramework, TArgs> & StoryAnnotations<TFramework, TArgs>;
+> = StoryFn<TFramework, Args> & StoryAnnotations<TFramework, TArgs>;
 
 export type LegacyStoryAnnotationsOrFn<
   TFramework extends AnyFramework = AnyFramework,
@@ -299,7 +299,7 @@ export type LegacyStoryAnnotationsOrFn<
 export type AnnotatedStoryFn<
   TFramework extends AnyFramework = AnyFramework,
   TArgs = Args
-> = ArgsStoryFn<TFramework, TArgs> & StoryAnnotations<TFramework, TArgs>;
+> = ArgsStoryFn<TFramework, Args> & StoryAnnotations<TFramework, TArgs>;
 
 export type StoryAnnotationsOrFn<TFramework extends AnyFramework = AnyFramework, TArgs = Args> =
   | AnnotatedStoryFn<TFramework, TArgs>

--- a/src/story.ts
+++ b/src/story.ts
@@ -174,11 +174,6 @@ export type BaseAnnotations<TFramework extends AnyFramework = AnyFramework, TArg
    * Define a custom render function for the story(ies). If not passed, a default render function by the framework will be used.
    */
   render?: ArgsStoryFn<TFramework, Args>;
-
-  /**
-   * Function that is executed after the story is rendered.
-   */
-  play?: PlayFunction<TFramework, Args>;
 };
 
 export type ProjectAnnotations<
@@ -265,7 +260,14 @@ export type ComponentAnnotations<
    *
    * By defining them each component will have its tab in the args table.
    */
-  subcomponents?: Record<string, TFramework['component']>;
+    subcomponents?: Record<string, TFramework['component']>;
+  
+
+
+  /**
+   * Function that is executed after the story is rendered.
+   */
+  play?: PlayFunction<TFramework, TArgs>;
 };
 
 export type StoryAnnotations<
@@ -281,6 +283,11 @@ export type StoryAnnotations<
    * Override the display name in the UI (CSF v2)
    */
   storyName?: StoryName;
+  
+  /**
+   * Function that is executed after the story is rendered.
+   */
+  play?: PlayFunction<TFramework, TArgs>;
 
   /** @deprecated */
   story?: Omit<StoryAnnotations<TFramework, TArgs>, 'story'>;
@@ -289,7 +296,7 @@ export type StoryAnnotations<
 export type LegacyAnnotatedStoryFn<
   TFramework extends AnyFramework = AnyFramework,
   TArgs = Args
-> = StoryFn<TFramework, Args> & StoryAnnotations<TFramework, TArgs>;
+> = StoryFn<TFramework, TArgs> & StoryAnnotations<TFramework, TArgs>;
 
 export type LegacyStoryAnnotationsOrFn<
   TFramework extends AnyFramework = AnyFramework,
@@ -299,7 +306,7 @@ export type LegacyStoryAnnotationsOrFn<
 export type AnnotatedStoryFn<
   TFramework extends AnyFramework = AnyFramework,
   TArgs = Args
-> = ArgsStoryFn<TFramework, Args> & StoryAnnotations<TFramework, TArgs>;
+> = ArgsStoryFn<TFramework, TArgs> & StoryAnnotations<TFramework, TArgs>;
 
 export type StoryAnnotationsOrFn<TFramework extends AnyFramework = AnyFramework, TArgs = Args> =
   | AnnotatedStoryFn<TFramework, TArgs>


### PR DESCRIPTION
See [this discussion](https://github.com/storybookjs/storybook/discussions/16843).

In this PR we basically only parameterise `args` and `argTypes` by `TArgs`. All other annotations (the story functions and contexts, the decorators/loaders/play fn) are generic to `Args`.

The point being is two things:

 - that at any given level (project / component / story) the definition of `TArgs` you pass in doesn't describe the entire story's args as the three levels are composed together [1]. All it does is describe the args you are defining at that level.

 - you also might want to use decorators/loaders/play functions that are more generic than a single story/component, without having to type cast them[2].

[1] This might be controversial to folks that are trying to be very precise and not use arg inheritance at all.
[2] I'm a little bit bemused you do need to type cast them, we probably need to unpack this a bit more.