### PR TITLE
Add toString to fix bug in storybook

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -8,6 +8,9 @@ import startCase from 'lodash/startCase';
 export const sanitize = (string: string) => {
   return (
     string
+      // Storybook will occasionally pass a number which throws.
+      // This prevents that from crashing a build.
+      .toString()
       .toLowerCase()
       // eslint-disable-next-line no-useless-escape
       .replace(/[ ’–—―′¿'`~!@#$%^&*()_|+\-=?;:'",.<>\{\}\[\]\\\/]/gi, '-')


### PR DESCRIPTION
Storybook seems to be passing integers to sanitize causing it to crash the application. I've tested that adding toString prevents it from breaking.