### PR TITLE
Fix annotation params not using TArgs generic

### DIFF
--- a/src/story.ts
+++ b/src/story.ts
@@ -144,7 +144,7 @@ export type BaseAnnotations<TFramework extends AnyFramework = AnyFramework, TArg
    * Decorators defined in Meta will be applied to every story variation.
    * @see [Decorators](https://storybook.js.org/docs/addons/introduction/#1-decorators)
    */
-  decorators?: DecoratorFunction<TFramework, Args>[];
+  decorators?: DecoratorFunction<TFramework, TArgs>[];
 
   /**
    * Custom metadata for a story.
@@ -168,23 +168,23 @@ export type BaseAnnotations<TFramework extends AnyFramework = AnyFramework, TArg
    * Asynchronous functions which provide data for a story.
    * @see [Loaders](https://storybook.js.org/docs/react/writing-stories/loaders)
    */
-  loaders?: LoaderFunction<TFramework, Args>[];
+  loaders?: LoaderFunction<TFramework, TArgs>[];
 
   /**
    * Define a custom render function for the story(ies). If not passed, a default render function by the framework will be used.
    */
-  render?: ArgsStoryFn<TFramework, Args>;
+  render?: ArgsStoryFn<TFramework, TArgs>;
 };
 
 export type ProjectAnnotations<
   TFramework extends AnyFramework = AnyFramework,
   TArgs = Args
 > = BaseAnnotations<TFramework, TArgs> & {
-  argsEnhancers?: ArgsEnhancer<TFramework, Args>[];
-  argTypesEnhancers?: ArgTypesEnhancer<TFramework, Args>[];
+  argsEnhancers?: ArgsEnhancer<TFramework, TArgs>[];
+  argTypesEnhancers?: ArgTypesEnhancer<TFramework, TArgs>[];
   globals?: Globals;
   globalTypes?: GlobalTypes;
-  applyDecorators?: DecoratorApplicator<TFramework, Args>;
+  applyDecorators?: DecoratorApplicator<TFramework, TArgs>;
 };
 
 type StoryDescriptor = string[] | RegExp;
@@ -276,7 +276,7 @@ export type StoryAnnotations<
    * Override the display name in the UI (CSF v2)
    */
   storyName?: StoryName;
-  
+
   /**
    * Function that is executed after the story is rendered.
    */


### PR DESCRIPTION
👋 Hello!

I ran into some type errors after updating to `@lastest` today. Specifically in decorator functions, `args` was not getting typed correctly.

e.g.,
```ts
type Args = { foo: number }
export default {
  decorators: [
    (Story, { args }) => { // <- args: any
      ...
    }
  ]
} as Meta<Args>
```

After diving into the types, I saw `DecoratorFunction` was being passed `Args` instead of the generic `TArgs` that would flow through from the `Meta<Args>` type.

I saw a few other similar uses of `Args` and assumed this was a similar issue so I changed those as well. Let me know if I am missing some context and those should specifically _not_ be "parameterized" with the generic `TArgs`.

I also wasn't sure exactly which branch to open this PR against. Kyle Gach pointed me to the `6-4-new-types` branch on Discord so I'm going based on that. Let me know if I need to update that.

Thanks!