### PR TITLE
Add tags annotation at all levels

### DIFF
--- a/src/story.test.ts
+++ b/src/story.test.ts
@@ -33,6 +33,7 @@ const Button = (props: ButtonArgs) => 'Button';
 const simple: XMeta = {
   title: 'simple',
   component: Button,
+  tags: ['foo', 'bar'],
   decorators: [(storyFn, context) => `withDecorator(${storyFn(context)})`],
   parameters: { a: () => null, b: NaN, c: Symbol('symbol') },
   loaders: [() => Promise.resolve({ d: '3' })],
@@ -43,6 +44,7 @@ const simple: XMeta = {
 const strict: XMeta<ButtonArgs> = {
   title: 'simple',
   component: Button,
+  tags: ['foo', 'bar'],
   decorators: [(storyFn, context) => `withDecorator(${storyFn(context)})`],
   parameters: { a: () => null, b: NaN, c: Symbol('symbol') },
   loaders: [() => Promise.resolve({ d: '3' })],
@@ -56,7 +58,8 @@ const Simple: XStory = () => 'Simple';
 const CSF1Story: XStory = () => 'Named Story';
 CSF1Story.story = {
   name: 'Another name for story',
-  decorators: [(storyFn) => `Wrapped(${storyFn()}`],
+  tags: ['foo', 'bar'],
+  decorators: [storyFn => `Wrapped(${storyFn()}`],
   parameters: { a: [1, '2', {}], b: undefined, c: Button },
   loaders: [() => Promise.resolve({ d: '3' })],
   args: { a: 1 },
@@ -64,24 +67,27 @@ CSF1Story.story = {
 
 const CSF2Story: XStory = () => 'Named Story';
 CSF2Story.storyName = 'Another name for story';
-CSF2Story.decorators = [(storyFn) => `Wrapped(${storyFn()}`];
+CSF2Story.tags = ['foo', 'bar'];
+CSF2Story.decorators = [storyFn => `Wrapped(${storyFn()}`];
 CSF2Story.parameters = { a: [1, '2', {}], b: undefined, c: Button };
 CSF2Story.loaders = [() => Promise.resolve({ d: '3' })];
 CSF2Story.args = { a: 1 };
 
 const CSF3Story: XStory = {
-  render: (args) => 'Named Story',
+  render: args => 'Named Story',
   name: 'Another name for story',
-  decorators: [(storyFn) => `Wrapped(${storyFn()}`],
+  tags: ['foo', 'bar'],
+  decorators: [storyFn => `Wrapped(${storyFn()}`],
   parameters: { a: [1, '2', {}], b: undefined, c: Button },
   loaders: [() => Promise.resolve({ d: '3' })],
   args: { a: 1 },
 };
 
 const CSF3StoryStrict: XStory<ButtonArgs> = {
-  render: (args) => 'Named Story',
+  render: args => 'Named Story',
   name: 'Another name for story',
-  decorators: [(storyFn) => `Wrapped(${storyFn()}`],
+  tags: ['foo', 'bar'],
+  decorators: [storyFn => `Wrapped(${storyFn()}`],
   parameters: { a: [1, '2', {}], b: undefined, c: Button },
   loaders: [() => Promise.resolve({ d: '3' })],
   args: { x: '1' },
@@ -93,6 +99,7 @@ const CSF3StoryStrict: XStory<ButtonArgs> = {
 };
 
 const project: ProjectAnnotations<XFramework> = {
+  tags: ['foo', 'bar'],
   async runStep(label, play, context) {
     return play(context);
   },
@@ -113,7 +120,7 @@ test('ArgsFromMeta will infer correct args from render/loader/decorators', () =>
     loader2: `${args.loaderArg2}`,
   });
 
-  const renderer: ArgsStoryFn<XFramework, { theme: string }> = (args) => `${args.theme}`;
+  const renderer: ArgsStoryFn<XFramework, { theme: string }> = args => `${args.theme}`;
 
   const meta = {
     component: Button,

--- a/src/story.test.ts
+++ b/src/story.test.ts
@@ -99,7 +99,6 @@ const CSF3StoryStrict: XStory<ButtonArgs> = {
 };
 
 const project: ProjectAnnotations<XFramework> = {
-  tags: ['foo', 'bar'],
   async runStep(label, play, context) {
     return play(context);
   },

--- a/src/story.ts
+++ b/src/story.ts
@@ -173,11 +173,6 @@ export type StepRunner<TFramework extends AnyFramework = AnyFramework, TArgs = A
 
 export type BaseAnnotations<TFramework extends AnyFramework = AnyFramework, TArgs = Args> = {
   /**
-   * Named tags for a story, used to filter stories in different contexts.
-   */
-  tags?: Tag[];
-
-  /**
    * Wrapper components or Storybook decorators that wrap a story.
    *
    * Decorators defined in Meta will be applied to every story variation.
@@ -304,6 +299,11 @@ export interface ComponentAnnotations<TFramework extends AnyFramework = AnyFrame
    * Function that is executed after the story is rendered.
    */
   play?: PlayFunction<TFramework, TArgs>;
+
+  /**
+   * Named tags for a story, used to filter stories in different contexts.
+   */
+  tags?: Tag[];
 }
 
 export type StoryAnnotations<
@@ -325,6 +325,11 @@ export type StoryAnnotations<
    * Function that is executed after the story is rendered.
    */
   play?: PlayFunction<TFramework, TArgs>;
+
+  /**
+   * Named tags for a story, used to filter stories in different contexts.
+   */
+  tags?: Tag[];
 
   /** @deprecated */
   story?: Omit<StoryAnnotations<TFramework, TArgs>, 'story'>;

--- a/src/story.ts
+++ b/src/story.ts
@@ -11,6 +11,8 @@ export type StoryName = string;
 /** @deprecated */
 export type StoryKind = ComponentTitle;
 
+export type Tag = string;
+
 export interface StoryIdentifier {
   componentId: ComponentId;
   title: ComponentTitle;
@@ -21,6 +23,8 @@ export interface StoryIdentifier {
   name: StoryName;
   /** @deprecated */
   story: StoryName;
+
+  tags: Tag[];
 }
 
 export type Parameters = { [name: string]: any };
@@ -169,6 +173,11 @@ export type StepRunner<TFramework extends AnyFramework = AnyFramework, TArgs = A
 
 export type BaseAnnotations<TFramework extends AnyFramework = AnyFramework, TArgs = Args> = {
   /**
+   * Named tags for a story, used to filter stories in different contexts.
+   */
+  tags?: Tag[];
+
+  /**
    * Wrapper components or Storybook decorators that wrap a story.
    *
    * Decorators defined in Meta will be applied to every story variation.
@@ -290,12 +299,12 @@ export interface ComponentAnnotations<TFramework extends AnyFramework = AnyFrame
    * By defining them each component will have its tab in the args table.
    */
   subcomponents?: Record<string, TFramework['component']>;
-  
+
   /**
    * Function that is executed after the story is rendered.
    */
   play?: PlayFunction<TFramework, TArgs>;
-};
+}
 
 export type StoryAnnotations<
   TFramework extends AnyFramework = AnyFramework,


### PR DESCRIPTION
Right now `type Tag = string`; which mirrors other project-defined things like globals + parameters.

<strike>Note I added support for them at the project level (i.e. add a tag to all stories). We want that right @shilman?</strike>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>0.0.2--canary.52.d2acbe4.0</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @storybook/csf@0.0.2--canary.52.d2acbe4.0
  # or 
  yarn add @storybook/csf@0.0.2--canary.52.d2acbe4.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
