### PR TITLE
Revert stricter parameters

### DIFF
--- a/src/story.ts
+++ b/src/story.ts
@@ -27,7 +27,7 @@ export interface StoryIdentifier {
 }
 
 export interface Parameters {
-  [name: string]: unknown;
+  [name: string]: any;
 }
 
 type ConditionalTest = { truthy?: boolean } | { exists: boolean } | { eq: any } | { neq: any };


### PR DESCRIPTION
The type safety it brings mostly applies to internal storybook code and addons. To get this extra type safety, we should first get proper interfaces for Parameters for all the addons in the monorepo.