### PR TITLE
Update story.ts

### DIFF
--- a/src/story.ts
+++ b/src/story.ts
@@ -344,6 +344,13 @@ export type StoryAnnotations<
   storyName?: StoryName;
 
   /**
+   * The primary component for your story.
+   *
+   * Used by addons for automatic prop table generation and display of other component metadata.
+   */
+  component?: (TRenderer & { T: Args extends TArgs ? any : TArgs })['component'];
+
+  /**
    * Function that is executed after the story is rendered.
    */
   play?: PlayFunction<TRenderer, TArgs>;


### PR DESCRIPTION
Add story as prop, as it works as expected, but just isn't exposed.

I wanted to test out some functionality real quick and wanted to wrap the component in another tag to make sure some events worked correctly, but noticed this type was not exposed.

is there a reason for that? or just maybe overlooked?