### PR TITLE
Turn Args interfaces into types when passed to decorators

### DIFF
--- a/src/story.ts
+++ b/src/story.ts
@@ -200,7 +200,7 @@ export type BaseAnnotations<TRenderer extends Renderer = Renderer, TArgs = Args>
    * Decorators defined in Meta will be applied to every story variation.
    * @see [Decorators](https://storybook.js.org/docs/addons/introduction/#1-decorators)
    */
-  decorators?: DecoratorFunction<TRenderer, TArgs>[];
+  decorators?: DecoratorFunction<TRenderer, Simplify<TArgs>>[];
 
   /**
    * Custom metadata for a story.


### PR DESCRIPTION
Turn Args interfaces into types when passed to decorators

Testing it in the monorepo
<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>0.0.2--canary.65.ef100c4.0</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @storybook/csf@0.0.2--canary.65.ef100c4.0
  # or 
  yarn add @storybook/csf@0.0.2--canary.65.ef100c4.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
