### PR TITLE
fix: better handle readonly InputType options

### DIFF
--- a/src/story.test.ts
+++ b/src/story.test.ts
@@ -57,6 +57,25 @@ const strict: XMeta<ButtonArgs> = {
   argTypes: { x: { type: { name: 'string' } } },
 };
 
+const options = ['foo', 'bar'] as const;
+const simpleWithReadonlyOptions: XMeta<ButtonArgs> = {
+  title: 'simple',
+  component: Button,
+  tags: ['foo', 'bar'],
+  decorators: [(storyFn, context) => `withDecorator(${storyFn(context)})`],
+  parameters: { a: () => null, b: NaN, c: Symbol('symbol') },
+  loaders: [() => Promise.resolve({ d: '3' })],
+  args: { x: '1' },
+  argTypes: {
+    x: {
+      control: {
+        type: 'select',
+      },
+      options: options,
+    }
+  },
+}
+
 // NOTE Various story usages
 const Simple: XStory = () => 'Simple';
 

--- a/src/story.ts
+++ b/src/story.ts
@@ -131,7 +131,7 @@ export interface InputType {
   /**
    * @see https://storybook.js.org/docs/api/arg-types#options
    */
-  options?: any[];
+  options?: readonly any[];
   /**
    * @see https://storybook.js.org/docs/api/arg-types#table
    */


### PR DESCRIPTION
Fixes https://github.com/storybookjs/storybook/issues/26912

Example that previously worked:
```ts
// MyComponent.tsx
export const sizes = ['small', 'medium', 'large'] as const;
type Size = (typeof sizes)[number];

// MyComponent.stories.tsx
const meta: Meta = {
  ...
  argTypes: {
    size: { options: sizes },
  },
  ...
};
```

But since the latest version here and release of storybook 8.0.9, now errors with:
```
The type readonly ['small', 'medium', 'large'] is readonly and cannot be assigned to the mutable type any[]
```

By adding `readonly` to this type, it supports both examples just fine as per https://www.typescriptlang.org/play?#code/C4TwDgpgBAhgdiAKgCwJZwOZQLxQE4QwAmA9nADYiwIDaAugNwBQTAxmQM7BQckC2EYGkw4oNAEQAzEiXEAaKOIBGMPOLqwOUdnC7MdXHv0HCMAUXIdouGgEYFAJgUBmRiwPdeAoegwBBBAAuaiRTUS8TX31OT2MfTAsrAJBg+FDfcLjTRIgGIA

I included a test for this too to prevent a regression. Let me know if there's anything else required.