### PR TITLE
Types: use readonly array for options.

### DIFF
--- a/src/story.ts
+++ b/src/story.ts
@@ -131,7 +131,7 @@ export interface InputType {
   /**
    * @see https://storybook.js.org/docs/api/arg-types#options
    */
-  options?: any[];
+  options?: readonly any[];
   /**
    * @see https://storybook.js.org/docs/api/arg-types#table
    */


### PR DESCRIPTION
By default arrays are mutable in Typescript, however when defining an InputType, we won't modify the initial value.

This allows to define some const values for options.