### PR TITLE
Add project initialGlobals & component/story globals, deprecate project globals

### DIFF
--- a/src/story.ts
+++ b/src/story.ts
@@ -494,6 +494,11 @@ export interface ComponentAnnotations<TRenderer extends Renderer = Renderer, TAr
    * Function that is executed after the story is rendered.
    */
   play?: PlayFunction<TRenderer, TArgs>;
+
+  /**
+   * Override the globals values for all stories in this component
+   */
+  globals?: Globals;
 }
 
 export type StoryAnnotations<
@@ -515,6 +520,11 @@ export type StoryAnnotations<
    * Function that is executed after the story is rendered.
    */
   play?: PlayFunction<TRenderer, TArgs>;
+
+  /**
+   * Override the globals values for this story
+   */
+  globals?: Globals;
 
   /** @deprecated */
   story?: Omit<StoryAnnotations<TRenderer, TArgs>, 'story'>;

--- a/src/story.ts
+++ b/src/story.ts
@@ -390,7 +390,11 @@ export type ProjectAnnotations<
 > = BaseAnnotations<TRenderer, TArgs> & {
   argsEnhancers?: ArgsEnhancer<TRenderer, Args>[];
   argTypesEnhancers?: ArgTypesEnhancer<TRenderer, Args>[];
+  /**
+   * @deprecated Project `globals` renamed to `initiaGlobals`
+   */
   globals?: Globals;
+  initialGlobals?: Globals;
   globalTypes?: GlobalTypes;
   applyDecorators?: DecoratorApplicator<TRenderer, Args>;
   runStep?: StepRunner<TRenderer, TArgs>;


### PR DESCRIPTION
CSF updates to implement `Story globals` per https://github.com/storybookjs/storybook/discussions/23347#discussioncomment-9575546
- [x] Add `preview.js` `initialGlobals` to replace `globals`
- [x] Deprecate `preview.js` `globals`
- [x] Add `globals` to component/story annotations

<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>0.1.8--canary.92.6fb63cd.0</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @storybook/csf@0.1.8--canary.92.6fb63cd.0
  # or 
  yarn add @storybook/csf@0.1.8--canary.92.6fb63cd.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
