### PR TITLE
fix: Explicitly allow undefined type for table.type.summary

### DIFF
--- a/src/story.ts
+++ b/src/story.ts
@@ -156,7 +156,7 @@ export interface InputType {
     /**
      * @see https://storybook.js.org/docs/api/arg-types#tabletype
      */
-    type?: { summary?: string; detail?: string };
+    type?: { summary?: string | undefined; detail?: string };
   };
   /**
    * @see https://storybook.js.org/docs/api/arg-types#type


### PR DESCRIPTION
Closes storybookjs/storybook#27129

Allowing explicitly `undefined` as type for `table.type.summary` lets Story authors disable the automatic type summary while having strict TypeScript options. With `exactOptionalPropertyTypes` enforced, using `undefined` as a type was forbidden, as TypeScript would raise an error. With this change, it should be allowed.