### PR TITLE
Add `context.storyGlobals`

### DIFF
--- a/src/story.ts
+++ b/src/story.ts
@@ -227,6 +227,7 @@ export interface StoryContextForEnhancers<TRenderer extends Renderer = Renderer,
   parameters: Parameters;
   initialArgs: TArgs;
   argTypes: StrictArgTypes<TArgs>;
+  storyGlobals: Globals;
 }
 
 export type ArgsEnhancer<TRenderer extends Renderer = Renderer, TArgs = Args> = (


### PR DESCRIPTION
Following on from https://github.com/ComponentDriven/csf/pull/92 -- add `context.storyGlobals`.

This is added to the very initial context (`ContextForEnhancers`) reflecting that we know it from back then.

Later (at render time) we'll also gain `context.globals`; which is the story's globals combined with the current value of the "user globals". Typically this is what user code would look at.

I'm not sure if we want to also add `context.userGlobals` to that layer (`ContextForEnhancers`) -- strictly speaking you cannot infer `userGlobals` from `globals - storyGlobals`. Then again it's unclear why you'd want to know the value of an overridden "user global".

Second question: should we make `context.storyGlobals` nullable, if the story does not set any global overrides?
<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>0.1.12--canary.95.1b1fb52.0</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install @storybook/csf@0.1.12--canary.95.1b1fb52.0
  # or 
  yarn add @storybook/csf@0.1.12--canary.95.1b1fb52.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
